### PR TITLE
Specify a default `trailers` entry in request

### DIFF
--- a/yakbak-proxy.js
+++ b/yakbak-proxy.js
@@ -52,7 +52,10 @@ http.createServer(yakbak(options.server, {
   dirname: path.resolve(options.tapes),
   noRecord: options.norecord,
   hash: (req, originalBody) => {
-    const extras = {};
+    const extras = {
+      trailers: {}
+    };
+    
     if (options.ignoreheaders) extras.headers = {};
     let body = originalBody;
     if (req.method === 'POST' && options.exciseid) {


### PR DESCRIPTION
incoming-message-hash always attempts to sort the trailers:
  https://github.com/flickr/incoming-message-hash/blob/431a52791b1093340d084af081746b2dcccfcff7/index.js#L43

This will throw an error if trailers is undefined:
> Object.keys(undefined)
Uncaught TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)

I added a default entry in the request so that an error isn't thrown from within i-m-h