### PR TITLE
Renovate uses rangeStrategy "replace"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "rangeStrategy": "replace"
 }


### PR DESCRIPTION
Should prevent it from trying to pin dependencies to specific versions.